### PR TITLE
(#4) ⭐ feat: JWT 인증 필터 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/controller/TestController.java
+++ b/backend/src/main/java/com/learnsnap/controller/TestController.java
@@ -59,7 +59,7 @@ public class TestController {
                 .orElse(null);
     }
 
-    // JWT 테스트 엔드포인트 (새로 추가!)
+    // JWT 테스트 엔드포인트 
     @GetMapping("/test/jwt")
     public Map<String, Object> testJwt() {
         String email = "test@example.com";
@@ -78,6 +78,27 @@ public class TestController {
         response.put("token", token);
         response.put("isValid", isValid);
         response.put("extractedEmail", extractedEmail);
+        
+        return response;
+    }
+    // JWT 인증 테스트 엔드포인트 
+    @GetMapping("/test/protected")
+    public Map<String, Object> protectedEndpoint() {
+        // SecurityContext에서 현재 인증된 사용자 정보 가져오기
+        org.springframework.security.core.Authentication authentication = 
+            org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        if (authentication != null && authentication.isAuthenticated()) {
+            response.put("authenticated", true);
+            response.put("email", authentication.getName());
+            response.put("authorities", authentication.getAuthorities());
+            response.put("message", "인증된 사용자입니다!");
+        } else {
+            response.put("authenticated", false);
+            response.put("message", "인증되지 않은 사용자입니다.");
+        }
         
         return response;
     }

--- a/backend/src/main/java/com/learnsnap/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/learnsnap/security/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.learnsnap.security;
+
+import com.learnsnap.domain.user.User;
+import com.learnsnap.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // 이메일로 사용자 찾기
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        // Spring Security의 UserDetails로 변환
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+        );
+    }
+}

--- a/backend/src/main/java/com/learnsnap/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/learnsnap/security/JwtAuthenticationFilter.java
@@ -1,0 +1,84 @@
+package com.learnsnap.security;
+
+import com.learnsnap.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        
+        final String authHeader = request.getHeader("Authorization");
+        final String jwt;
+        final String userEmail;
+
+        System.out.println("=== JWT Filter 실행 ===");
+        System.out.println("Authorization 헤더: " + authHeader);
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            System.out.println("토큰이 없거나 형식이 잘못됨");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        jwt = authHeader.substring(7);
+        System.out.println("추출된 JWT: " + jwt.substring(0, Math.min(jwt.length(), 20)) + "...");
+        
+        try {
+            userEmail = jwtUtil.extractEmail(jwt);
+            System.out.println("추출된 이메일: " + userEmail);
+
+            if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                
+                UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
+                System.out.println("사용자 찾음: " + userDetails.getUsername());
+
+                if (jwtUtil.validateToken(jwt, userDetails.getUsername())) {
+                    System.out.println("토큰 검증 성공!");
+                    
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+                    
+                    authToken.setDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request)
+                    );
+                    
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                    System.out.println("인증 완료!");
+                } else {
+                    System.out.println("토큰 검증 실패!");
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("JWT 인증 실패: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## 변경 사항
- JwtAuthenticationFilter 클래스 생성
- HTTP 요청에서 JWT 토큰 추출 로직
- 토큰 유효성 검증
- SecurityContext에 인증 정보 저장
- CustomUserDetailsService 구현
- SecurityConfig에 필터 등록
- 보호된 테스트 엔드포인트 추가 (/api/test/protected)

## 테스트 완료
- [x] JWT 필터가 정상 작동
- [x] 토큰 없이 접근 시 403 Forbidden
- [x] 토큰 포함 시 인증 성공
- [x] GET /api/test/protected 엔드포인트 테스트 성공

Closes #4