### PR TITLE
(#6) ⭐ feat: 회원가입 API 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/controller/AuthController.java
+++ b/backend/src/main/java/com/learnsnap/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.learnsnap.controller;
+
+import com.learnsnap.dto.SignUpRequest;
+import com.learnsnap.dto.SignUpResponse;
+import com.learnsnap.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {
+        SignUpResponse response = authService.signUp(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/dto/SignUpRequest.java
+++ b/backend/src/main/java/com/learnsnap/dto/SignUpRequest.java
@@ -1,0 +1,28 @@
+package com.learnsnap.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpRequest {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다")
+    private String password;
+
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+    private String username;
+}

--- a/backend/src/main/java/com/learnsnap/dto/SignUpResponse.java
+++ b/backend/src/main/java/com/learnsnap/dto/SignUpResponse.java
@@ -1,0 +1,22 @@
+package com.learnsnap.dto;
+
+import com.learnsnap.domain.user.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpResponse {
+
+    private Long id;
+    private String email;
+    private String username;
+    private Role role;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/learnsnap/exception/DuplicateEmailException.java
+++ b/backend/src/main/java/com/learnsnap/exception/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package com.learnsnap.exception;
+
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/exception/ErrorResponse.java
+++ b/backend/src/main/java/com/learnsnap/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.learnsnap.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ErrorResponse {
+    private LocalDateTime timestamp;
+    private int status;
+    private String error;
+    private String message;
+}

--- a/backend/src/main/java/com/learnsnap/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/learnsnap/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.learnsnap.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 이메일 중복 예외
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateEmail(DuplicateEmailException ex) {
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.CONFLICT.value())
+                .error("Conflict")
+                .message(ex.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    // 유효성 검증 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
+        
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("timestamp", LocalDateTime.now());
+        response.put("status", HttpStatus.BAD_REQUEST.value());
+        response.put("error", "Validation Failed");
+        response.put("errors", errors);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/service/AuthService.java
+++ b/backend/src/main/java/com/learnsnap/service/AuthService.java
@@ -1,0 +1,48 @@
+package com.learnsnap.service;
+
+import com.learnsnap.domain.user.Role;
+import com.learnsnap.domain.user.User;
+import com.learnsnap.dto.SignUpRequest;
+import com.learnsnap.dto.SignUpResponse;
+import com.learnsnap.exception.DuplicateEmailException;
+import com.learnsnap.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public SignUpResponse signUp(SignUpRequest request) {
+        // 1. 이메일 중복 체크
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateEmailException("이미 사용 중인 이메일입니다: " + request.getEmail());
+        }
+
+        // 2. User 엔티티 생성
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))  // 비밀번호 암호화
+                .username(request.getUsername())
+                .role(Role.LEARNER)  // 기본 역할
+                .build();
+
+        // 3. 저장
+        User savedUser = userRepository.save(user);
+
+        // 4. Response DTO로 변환
+        return SignUpResponse.builder()
+                .id(savedUser.getId())
+                .email(savedUser.getEmail())
+                .username(savedUser.getUsername())
+                .role(savedUser.getRole())
+                .createdAt(savedUser.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항
- SignUpRequest, SignUpResponse DTO 생성
- AuthService 생성 (회원가입 로직)
- AuthController 생성
- POST /api/auth/signup 엔드포인트 구현
- 이메일 중복 체크
- 비밀번호 암호화 (BCrypt)
- 입력 유효성 검증 (@Valid)
- 전역 예외 처리 (GlobalExceptionHandler)
- DuplicateEmailException 추가

## 테스트 완료
- [x] 정상 회원가입 성공
- [x] 이메일 중복 시 409 에러
- [x] 유효성 검증 실패 시 400 에러
- [x] 비밀번호 암호화 확인

Closes #6