### PR TITLE
(#7) ⭐ feat: 로그인 API 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/controller/AuthController.java
+++ b/backend/src/main/java/com/learnsnap/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.learnsnap.controller;
 
+import com.learnsnap.dto.LoginRequest;
+import com.learnsnap.dto.LoginResponse;
 import com.learnsnap.dto.SignUpRequest;
 import com.learnsnap.dto.SignUpResponse;
 import com.learnsnap.service.AuthService;
@@ -20,5 +22,12 @@ public class AuthController {
     public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {
         SignUpResponse response = authService.signUp(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 로그인 엔드포인트 
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/learnsnap/dto/LoginRequest.java
+++ b/backend/src/main/java/com/learnsnap/dto/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.learnsnap.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+}

--- a/backend/src/main/java/com/learnsnap/dto/LoginResponse.java
+++ b/backend/src/main/java/com/learnsnap/dto/LoginResponse.java
@@ -1,0 +1,27 @@
+package com.learnsnap.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginResponse {
+
+    private String accessToken;
+    private UserInfo user;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UserInfo {
+        private Long id;
+        private String email;
+        private String username;
+        private String role;
+    }
+}

--- a/backend/src/main/java/com/learnsnap/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/learnsnap/exception/GlobalExceptionHandler.java
@@ -27,6 +27,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
     }
 
+    // 잘못된 인증 정보 예외
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex) {
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .error("Unauthorized")
+                .message(ex.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+    }
+
     // 유효성 검증 예외
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> handleValidationExceptions(

--- a/backend/src/main/java/com/learnsnap/exception/InvalidCredentialsException.java
+++ b/backend/src/main/java/com/learnsnap/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package com.learnsnap.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/service/AuthService.java
+++ b/backend/src/main/java/com/learnsnap/service/AuthService.java
@@ -2,10 +2,14 @@ package com.learnsnap.service;
 
 import com.learnsnap.domain.user.Role;
 import com.learnsnap.domain.user.User;
+import com.learnsnap.dto.LoginRequest;
+import com.learnsnap.dto.LoginResponse;
 import com.learnsnap.dto.SignUpRequest;
 import com.learnsnap.dto.SignUpResponse;
 import com.learnsnap.exception.DuplicateEmailException;
+import com.learnsnap.exception.InvalidCredentialsException;
 import com.learnsnap.repository.UserRepository;
+import com.learnsnap.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;  
 
     @Transactional
     public SignUpResponse signUp(SignUpRequest request) {
@@ -28,9 +33,9 @@ public class AuthService {
         // 2. User 엔티티 생성
         User user = User.builder()
                 .email(request.getEmail())
-                .password(passwordEncoder.encode(request.getPassword()))  // 비밀번호 암호화
+                .password(passwordEncoder.encode(request.getPassword()))
                 .username(request.getUsername())
-                .role(Role.LEARNER)  // 기본 역할
+                .role(Role.LEARNER)
                 .build();
 
         // 3. 저장
@@ -43,6 +48,35 @@ public class AuthService {
                 .username(savedUser.getUsername())
                 .role(savedUser.getRole())
                 .createdAt(savedUser.getCreatedAt())
+                .build();
+    }
+
+    // 로그인 메서드 
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
+        // 1. 이메일로 사용자 찾기
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다"));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다");
+        }
+
+        // 3. JWT 토큰 생성
+        String accessToken = jwtUtil.generateToken(user.getEmail());
+
+        // 4. Response 생성
+        LoginResponse.UserInfo userInfo = LoginResponse.UserInfo.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .role(user.getRole().name())
+                .build();
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .user(userInfo)
                 .build();
     }
 }


### PR DESCRIPTION
## 변경 사항
- LoginRequest, LoginResponse DTO 생성
- AuthService에 로그인 메서드 추가
- POST /api/auth/login 엔드포인트 구현
- 이메일/비밀번호 검증
- JWT Access Token 발급
- InvalidCredentialsException 추가
- GlobalExceptionHandler에 인증 실패 예외 처리 추가

## 테스트 완료
- [x] 정상 로그인 성공 및 JWT 토큰 발급
- [x] 잘못된 비밀번호 시 401 에러
- [x] 존재하지 않는 이메일 시 401 에러
- [x] 발급받은 토큰으로 보호된 엔드포인트 접근 성공

Closes #7