### PR TITLE
(#8) ⭐ feat: 현재 사용자 정보 조회 및 프로필 업데이트 API 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/config/SecurityConfig.java
+++ b/backend/src/main/java/com/learnsnap/config/SecurityConfig.java
@@ -48,17 +48,20 @@ public class SecurityConfig {
                     "/api/test/users",
                     "/api/test/user",
                     "/api/test/user/**",
-                    "/api/auth/**"  // 나중에 로그인/회원가입 API
+                    "/api/auth/**"  // 로그인/회원가입
                 ).permitAll()
                 
-                // /api/test/protected는 인증 필요
-                .requestMatchers("/api/test/protected").authenticated()
+                // 인증 필요한 경로
+                .requestMatchers(
+                    "/api/test/protected",
+                    "/api/users/**"  
+                ).authenticated()
                 
                 // 나머지는 모두 허용 (개발 단계)
                 .anyRequest().permitAll()
             )
             
-            // JWT 필터 추가
+            // JWT 필터 
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/com/learnsnap/controller/UserController.java
+++ b/backend/src/main/java/com/learnsnap/controller/UserController.java
@@ -1,0 +1,42 @@
+package com.learnsnap.controller;
+
+import com.learnsnap.dto.UpdateProfileRequest;
+import com.learnsnap.dto.UserResponse;
+import com.learnsnap.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // 현재 사용자 정보 조회
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getCurrentUser() {
+        // SecurityContext에서 현재 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        UserResponse response = userService.getCurrentUser(email);
+        return ResponseEntity.ok(response);
+    }
+
+    // 프로필 업데이트 
+    @PutMapping("/me")
+    public ResponseEntity<UserResponse> updateProfile(
+            @Valid @RequestBody UpdateProfileRequest request) {
+        // SecurityContext에서 현재 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        UserResponse response = userService.updateProfile(email, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/domain/user/User.java
+++ b/backend/src/main/java/com/learnsnap/domain/user/User.java
@@ -50,12 +50,12 @@ public class User {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    // 비밀번호 변경 메서드 (나중에 사용)
+    // 비밀번호 변경 메서드 
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
 
-    // 프로필 업데이트 메서드 (나중에 사용)
+    // 프로필 업데이트 메서드 
     public void updateProfile(String username, String bio, String profileImage) {
         this.username = username;
         this.bio = bio;

--- a/backend/src/main/java/com/learnsnap/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/learnsnap/dto/UpdateProfileRequest.java
@@ -1,0 +1,23 @@
+package com.learnsnap.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateProfileRequest {
+
+    @Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+    private String username;
+
+    @Size(max = 500, message = "자기소개는 500자 이하여야 합니다")
+    private String bio;
+
+    @Size(max = 500, message = "프로필 이미지 URL은 500자 이하여야 합니다")
+    private String profileImage;
+}

--- a/backend/src/main/java/com/learnsnap/dto/UserResponse.java
+++ b/backend/src/main/java/com/learnsnap/dto/UserResponse.java
@@ -1,0 +1,24 @@
+package com.learnsnap.dto;
+
+import com.learnsnap.domain.user.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String username;
+    private Role role;
+    private String profileImage;
+    private String bio;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/learnsnap/service/UserService.java
+++ b/backend/src/main/java/com/learnsnap/service/UserService.java
@@ -1,0 +1,70 @@
+package com.learnsnap.service;
+
+import com.learnsnap.domain.user.User;
+import com.learnsnap.dto.UpdateProfileRequest;
+import com.learnsnap.dto.UserResponse;
+import com.learnsnap.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserResponse getCurrentUser(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .role(user.getRole())
+                .profileImage(user.getProfileImage())
+                .bio(user.getBio())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+
+    // 프로필 업데이트 메서드 
+    @Transactional
+    public UserResponse updateProfile(String email, UpdateProfileRequest request) {
+        // 1. 사용자 찾기
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        // 2. 프로필 업데이트 (null이 아닌 필드만 업데이트)
+        if (request.getUsername() != null) {
+            user.updateProfile(
+                request.getUsername(),
+                request.getBio() != null ? request.getBio() : user.getBio(),
+                request.getProfileImage() != null ? request.getProfileImage() : user.getProfileImage()
+            );
+        } else if (request.getBio() != null || request.getProfileImage() != null) {
+            user.updateProfile(
+                user.getUsername(),
+                request.getBio() != null ? request.getBio() : user.getBio(),
+                request.getProfileImage() != null ? request.getProfileImage() : user.getProfileImage()
+            );
+        }
+
+        // 3. 저장 (JPA dirty checking으로 자동 저장됨)
+        // userRepository.save(user); // @Transactional이 있어서 생략 가능
+
+        // 4. Response 반환
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .role(user.getRole())
+                .profileImage(user.getProfileImage())
+                .bio(user.getBio())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항
- UserResponse DTO 생성
- UpdateProfileRequest DTO 생성
- UserService 생성
  - getCurrentUser: 현재 사용자 정보 조회
  - updateProfile: 프로필 업데이트 (선택적 필드 업데이트)
- UserController 생성
  - GET /api/users/me: 현재 사용자 정보 조회
  - PUT /api/users/me: 프로필 업데이트
- SecurityConfig 수정
  - /api/users/** 경로 인증 필수 설정

## 주요 기능
### 1. 현재 사용자 정보 조회
- JWT 토큰에서 사용자 이메일 추출
- 사용자 정보 반환

### 2. 프로필 업데이트
- username, bio, profileImage 업데이트 가능
- 선택적 필드 업데이트 지원 (null이 아닌 필드만 업데이트)
- 입력 유효성 검증

## API 명세
### GET /api/users/me
- 인증: Required (Bearer Token)
- 응답: UserResponse

### PUT /api/users/me
- 인증: Required (Bearer Token)
- 요청: UpdateProfileRequest (username, bio, profileImage - 모두 선택)
- 응답: UserResponse

## 테스트 완료
- [x] 토큰 없이 GET /api/users/me 접근 → 403 Forbidden
- [x] 토큰 포함 GET /api/users/me → 200 OK, 사용자 정보 반환
- [x] 토큰 없이 PUT /api/users/me 접근 → 403 Forbidden
- [x] 전체 필드 업데이트 → 200 OK, 모든 필드 변경
- [x] 일부 필드만 업데이트 → 200 OK, 해당 필드만 변경
- [x] 유효성 검증 실패 (너무 짧은 username) → 400 Bad Request
- [x] 다른 사용자로 로그인 → 해당 사용자 정보만 조회/업데이트
- [x] 업데이트 후 조회 → 변경된 정보 확인

## 보안
- JWT 인증 필수
- 자신의 프로필만 조회/업데이트 가능
- SecurityContext에서 인증된 사용자 정보 추출

Closes #8