### PR TITLE
(#24) ⭐ feat: Category Entity 및 Repository 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/controller/TestController.java
+++ b/backend/src/main/java/com/learnsnap/controller/TestController.java
@@ -1,12 +1,15 @@
 package com.learnsnap.controller;
 
+import com.learnsnap.domain.category.Category;
 import com.learnsnap.domain.user.Role;
 import com.learnsnap.domain.user.User;
+import com.learnsnap.repository.CategoryRepository;
 import com.learnsnap.repository.UserRepository;
 import com.learnsnap.util.JwtUtil;
-
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,82 +18,62 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api")
-@RequiredArgsConstructor  
+@RequestMapping("/api/test")
+@RequiredArgsConstructor
 public class TestController {
 
-    private final UserRepository userRepository;  
+    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtUtil jwtUtil;  
+    private final JwtUtil jwtUtil;
+    private final CategoryRepository categoryRepository;
 
-    @GetMapping("/hello")
-    public String hello() {
-        return "Hello from LearnSnap Backend!";
+    @GetMapping("/users")
+    public ResponseEntity<List<User>> getAllUsers() {
+        List<User> users = userRepository.findAll();
+        return ResponseEntity.ok(users);
     }
 
-    @GetMapping("/status")
-    public String status() {
-        return "Backend is running successfully!";
-    }
-
-    // 테스트용: 사용자 생성 (비밀번호 암호화 적용)
-    @PostMapping("/test/user")
-    public User createTestUser() {
+    @PostMapping("/user")
+    public ResponseEntity<User> createTestUser() {
         User user = User.builder()
                 .email("test@example.com")
-                .password(passwordEncoder.encode("password123"))  // 암호화 추가!
+                .password(passwordEncoder.encode("password123"))
                 .username("테스트사용자")
                 .role(Role.LEARNER)
                 .build();
-
-        return userRepository.save(user);
+        
+        User savedUser = userRepository.save(user);
+        return ResponseEntity.ok(savedUser);
     }
 
-    // 테스트용: 모든 사용자 조회
-    @GetMapping("/test/users")
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    @GetMapping("/user/{email}")
+    public ResponseEntity<User> getUserByEmail(@PathVariable String email) {
+        User user = userRepository.findByEmail(email).orElse(null);
+        return ResponseEntity.ok(user);
     }
 
-    // 테스트용: 이메일로 사용자 찾기
-    @GetMapping("/test/user/{email}")
-    public User getUserByEmail(@PathVariable String email) {
-        return userRepository.findByEmail(email)
-                .orElse(null);
-    }
-
-    // JWT 테스트 엔드포인트 
-    @GetMapping("/test/jwt")
-    public Map<String, Object> testJwt() {
+    @GetMapping("/jwt")
+    public ResponseEntity<Map<String, Object>> testJwt() {
         String email = "test@example.com";
-        
-        // JWT 토큰 생성
         String token = jwtUtil.generateToken(email);
-        
-        // 토큰 검증
-        boolean isValid = jwtUtil.validateToken(token);
-        
-        // 토큰에서 이메일 추출
-        String extractedEmail = jwtUtil.extractEmail(token);
         
         Map<String, Object> response = new HashMap<>();
         response.put("email", email);
         response.put("token", token);
-        response.put("isValid", isValid);
-        response.put("extractedEmail", extractedEmail);
+        response.put("isValid", jwtUtil.validateToken(token, email));
+        response.put("extractedEmail", jwtUtil.extractEmail(token));
         
-        return response;
+        return ResponseEntity.ok(response);
     }
-    // JWT 인증 테스트 엔드포인트 
-    @GetMapping("/test/protected")
-    public Map<String, Object> protectedEndpoint() {
-        // SecurityContext에서 현재 인증된 사용자 정보 가져오기
-        org.springframework.security.core.Authentication authentication = 
-            org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+
+    @GetMapping("/protected")
+    public ResponseEntity<Map<String, Object>> protectedEndpoint() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         
         Map<String, Object> response = new HashMap<>();
         
-        if (authentication != null && authentication.isAuthenticated()) {
+        if (authentication != null && authentication.isAuthenticated() 
+                && !authentication.getPrincipal().equals("anonymousUser")) {
             response.put("authenticated", true);
             response.put("email", authentication.getName());
             response.put("authorities", authentication.getAuthorities());
@@ -100,6 +83,82 @@ public class TestController {
             response.put("message", "인증되지 않은 사용자입니다.");
         }
         
-        return response;
+        return ResponseEntity.ok(response);
+    }
+
+    // 카테고리 테스트 엔드포인트 추가
+    @PostMapping("/category")
+    public ResponseEntity<Category> createTestCategory() {
+        Category category = Category.builder()
+                .name("백엔드")
+                .slug("backend")
+                .description("백엔드 개발 관련 강의")
+                .icon("💻")
+                .build();
+        
+        Category saved = categoryRepository.save(category);
+        return ResponseEntity.ok(saved);
+    }
+
+    @GetMapping("/categories")
+    public ResponseEntity<List<Category>> getAllCategories() {
+        List<Category> categories = categoryRepository.findAll();
+        return ResponseEntity.ok(categories);
+    }
+
+    @GetMapping("/category/{slug}")
+    public ResponseEntity<Category> getCategoryBySlug(@PathVariable String slug) {
+        Category category = categoryRepository.findBySlug(slug).orElse(null);
+        return ResponseEntity.ok(category);
+    }
+
+    // 여러 카테고리 한 번에 생성
+    @PostMapping("/categories/init")
+    public ResponseEntity<List<Category>> initializeCategories() {
+        // 기존 카테고리 전부 삭제 (테스트용)
+        categoryRepository.deleteAll();
+        
+        // 5개 카테고리 생성
+        List<Category> categories = List.of(
+            Category.builder()
+                .name("백엔드")
+                .slug("backend")
+                .description("백엔드 개발 관련 강의 (Node.js, Python, Java, Spring Boot)")
+                .icon("💻")
+                .build(),
+            
+            Category.builder()
+                .name("프론트엔드")
+                .slug("frontend")
+                .description("프론트엔드 개발 관련 강의 (React, Vue, JavaScript)")
+                .icon("🎨")
+                .build(),
+            
+            Category.builder()
+                .name("DevOps")
+                .slug("devops")
+                .description("DevOps 및 인프라 관련 강의 (Docker, Kubernetes, CI/CD)")
+                .icon("🚀")
+                .build(),
+            
+            Category.builder()
+                .name("데이터베이스")
+                .slug("database")
+                .description("데이터베이스 관련 강의 (PostgreSQL, MySQL, MongoDB)")
+                .icon("🗄️")
+                .build(),
+            
+            Category.builder()
+                .name("AI/ML")
+                .slug("ai-ml")
+                .description("인공지능 및 머신러닝 관련 강의 (TensorFlow, PyTorch)")
+                .icon("🤖")
+                .build()
+        );
+        
+        // 모두 저장
+        List<Category> savedCategories = categoryRepository.saveAll(categories);
+        
+        return ResponseEntity.ok(savedCategories);
     }
 }

--- a/backend/src/main/java/com/learnsnap/domain/category/Category.java
+++ b/backend/src/main/java/com/learnsnap/domain/category/Category.java
@@ -1,0 +1,52 @@
+package com.learnsnap.domain.category;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String slug;  // URL 친화적인 이름 (예: "backend", "frontend")
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(length = 100)
+    private String icon;  // 아이콘 URL 또는 이름
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 카테고리 업데이트 메서드
+    public void update(String name, String slug, String description, String icon) {
+        this.name = name;
+        this.slug = slug;
+        this.description = description;
+        this.icon = icon;
+    }
+}

--- a/backend/src/main/java/com/learnsnap/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/learnsnap/repository/CategoryRepository.java
@@ -1,0 +1,20 @@
+package com.learnsnap.repository;
+
+import com.learnsnap.domain.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    // slug로 카테고리 찾기
+    Optional<Category> findBySlug(String slug);
+
+    // name으로 카테고리 존재 여부 확인
+    boolean existsByName(String name);
+
+    // slug로 카테고리 존재 여부 확인
+    boolean existsBySlug(String slug);
+}


### PR DESCRIPTION
## 변경 사항
- Category Entity 생성
- CategoryRepository 생성
- categories 테이블 자동 생성 확인
- TestController에 카테고리 테스트 엔드포인트 추가

## Category Entity 필드
- id (Long, PK)
- name (String, unique) - 카테고리 이름
- slug (String, unique) - URL 친화적 이름
- description (String) - 설명
- icon (String) - 아이콘
- createdAt, updatedAt (자동 생성)

## Repository 메서드
- findBySlug(String slug)
- existsByName(String name)
- existsBySlug(String slug)

## 테스트 완료
- [x] Category Entity 생성 및 테이블 생성 확인
- [x] POST /api/test/category - 카테고리 생성 성공
- [x] GET /api/test/categories - 전체 카테고리 조회
- [x] GET /api/test/category/{slug} - slug로 카테고리 찾기
- [x] 여러 카테고리 생성 테스트 (5개)
- [x] 데이터베이스에서 직접 확인

Closes #24