### PR TITLE
(#26) ⭐ feat: Video Entity 및 Repository 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/domain/video/DifficultyLevel.java
+++ b/backend/src/main/java/com/learnsnap/domain/video/DifficultyLevel.java
@@ -1,0 +1,7 @@
+package com.learnsnap.domain.video;
+
+public enum DifficultyLevel {
+    BEGINNER,       // 초급
+    INTERMEDIATE,   // 중급
+    ADVANCED        // 고급
+}

--- a/backend/src/main/java/com/learnsnap/domain/video/Video.java
+++ b/backend/src/main/java/com/learnsnap/domain/video/Video.java
@@ -1,0 +1,97 @@
+package com.learnsnap.domain.video;
+
+import com.learnsnap.domain.category.Category;
+import com.learnsnap.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "videos")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Video {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(nullable = false, length = 500)
+    private String videoUrl;  // S3 URL
+
+    @Column(length = 500)
+    private String thumbnailUrl;  // 썸네일 S3 URL
+
+    @Column(nullable = false)
+    private Integer duration;  // 재생 시간 (초)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DifficultyLevel difficultyLevel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instructor_id", nullable = false)
+    private User instructor;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Long viewsCount = 0L;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Long likesCount = 0L;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 비디오 업데이트 메서드
+    public void update(String title, String description, String thumbnailUrl, 
+                      Integer duration, DifficultyLevel difficultyLevel, Category category) {
+        this.title = title;
+        this.description = description;
+        this.thumbnailUrl = thumbnailUrl;
+        this.duration = duration;
+        this.difficultyLevel = difficultyLevel;
+        this.category = category;
+    }
+
+    // 조회수 증가
+    public void incrementViews() {
+        this.viewsCount++;
+    }
+
+    // 좋아요 증가
+    public void incrementLikes() {
+        this.likesCount++;
+    }
+
+    // 좋아요 감소
+    public void decrementLikes() {
+        if (this.likesCount > 0) {
+            this.likesCount--;
+        }
+    }
+}

--- a/backend/src/main/java/com/learnsnap/repository/VideoRepository.java
+++ b/backend/src/main/java/com/learnsnap/repository/VideoRepository.java
@@ -1,0 +1,48 @@
+package com.learnsnap.repository;
+
+import com.learnsnap.domain.category.Category;
+import com.learnsnap.domain.user.User;
+import com.learnsnap.domain.video.DifficultyLevel;
+import com.learnsnap.domain.video.Video;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface VideoRepository extends JpaRepository<Video, Long> {
+
+    // 카테고리로 조회
+    Page<Video> findByCategory(Category category, Pageable pageable);
+
+    // 카테고리 ID로 조회
+    Page<Video> findByCategoryId(Long categoryId, Pageable pageable);
+
+    // 강사로 조회
+    Page<Video> findByInstructor(User instructor, Pageable pageable);
+
+    // 강사 ID로 조회
+    Page<Video> findByInstructorId(Long instructorId, Pageable pageable);
+
+    // 난이도로 조회
+    Page<Video> findByDifficultyLevel(DifficultyLevel difficultyLevel, Pageable pageable);
+
+    // 제목으로 검색
+    Page<Video> findByTitleContaining(String keyword, Pageable pageable);
+
+    // 제목 또는 설명으로 검색
+    Page<Video> findByTitleContainingOrDescriptionContaining(
+            String titleKeyword, String descKeyword, Pageable pageable);
+
+    // 카테고리와 난이도로 조회
+    Page<Video> findByCategoryIdAndDifficultyLevel(
+            Long categoryId, DifficultyLevel difficultyLevel, Pageable pageable);
+
+    // 조회수 많은 순 (인기 비디오)
+    List<Video> findTop10ByOrderByViewsCountDesc();
+
+    // 최신 비디오
+    List<Video> findTop10ByOrderByCreatedAtDesc();
+}


### PR DESCRIPTION
## 변경 사항
- DifficultyLevel Enum 생성 (BEGINNER, INTERMEDIATE, ADVANCED)
- Video Entity 생성
- VideoRepository 생성
- videos 테이블 자동 생성 확인
- Category와 ManyToOne 관계 설정
- User(강사)와 ManyToOne 관계 설정
- TestController에 비디오 테스트 엔드포인트 추가

## Video Entity 필드
- id, title, description
- videoUrl, thumbnailUrl (S3 URL 예정)
- duration (재생 시간, 초)
- difficultyLevel (난이도 Enum)
- category (ManyToOne)
- instructor (ManyToOne)
- viewsCount, likesCount (기본값 0)
- createdAt, updatedAt (자동 생성)

## Video 메서드
- update() - 비디오 정보 업데이트
- incrementViews() - 조회수 증가
- incrementLikes() - 좋아요 증가
- decrementLikes() - 좋아요 감소

## Repository 메서드
- findByCategory / findByCategoryId
- findByInstructor / findByInstructorId
- findByDifficultyLevel
- findByTitleContaining (검색)
- findByTitleContainingOrDescriptionContaining (검색)
- findByCategoryIdAndDifficultyLevel (필터)
- findTop10ByOrderByViewsCountDesc (인기 비디오)
- findTop10ByOrderByCreatedAtDesc (최신 비디오)

## 테스트 완료
- [x] Video Entity 생성 및 테이블 생성 확인
- [x] DifficultyLevel Enum 동작 확인
- [x] Category와의 ManyToOne 관계 확인
- [x] User와의 ManyToOne 관계 확인
- [x] POST /api/test/video - 단일 비디오 생성
- [x] POST /api/test/videos/init - 5개 비디오 생성
- [x] GET /api/test/videos - 전체 비디오 조회
- [x] 데이터베이스에서 관계 확인 (JOIN 쿼리)

Closes #26