### PR TITLE
(#28) ⭐ feat: Video CRUD API 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/config/SecurityConfig.java
+++ b/backend/src/main/java/com/learnsnap/config/SecurityConfig.java
@@ -48,8 +48,11 @@ public class SecurityConfig {
                     "/api/status",
                     "/api/test/**",
                     "/api/auth/**",
-                    "/api/categories",      // GET /api/categories (전체 조회)
-                    "/api/categories/**"    // GET /api/categories/{id} (특정 조회)
+                    "/api/categories",
+                    "/api/categories/**",
+                    "/api/videos",           // GET /api/videos (전체 조회)
+                    "/api/videos/*",         // GET /api/videos/{id} (특정 조회)
+                    "/api/videos/*/view"     // POST /api/videos/{id}/view (조회수 증가)
                 ).permitAll()
                 
                 // 인증 필요한 경로

--- a/backend/src/main/java/com/learnsnap/controller/TestController.java
+++ b/backend/src/main/java/com/learnsnap/controller/TestController.java
@@ -311,4 +311,18 @@ public class TestController {
         List<Video> savedVideos = videoRepository.saveAll(videos);
         return ResponseEntity.ok(savedVideos);
     }
+
+    // 강사 사용자 생성
+    @PostMapping("/instructor")
+    public ResponseEntity<User> createInstructorUser() {
+        User instructor = User.builder()
+                .email("instructor@learnsnap.com")
+                .password(passwordEncoder.encode("instructor123"))
+                .username("강사")
+                .role(Role.INSTRUCTOR)
+                .build();
+        
+        User savedInstructor = userRepository.save(instructor);
+        return ResponseEntity.ok(savedInstructor);
+    }
 }

--- a/backend/src/main/java/com/learnsnap/controller/VideoController.java
+++ b/backend/src/main/java/com/learnsnap/controller/VideoController.java
@@ -1,0 +1,104 @@
+package com.learnsnap.controller;
+
+import com.learnsnap.domain.video.DifficultyLevel;
+import com.learnsnap.dto.VideoRequest;
+import com.learnsnap.dto.VideoResponse;
+import com.learnsnap.service.VideoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/videos")
+@RequiredArgsConstructor
+public class VideoController {
+
+    private final VideoService videoService;
+
+    // 전체 비디오 조회 (페이징)
+    @GetMapping
+    public ResponseEntity<Page<VideoResponse>> getAllVideos(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sort,
+            @RequestParam(defaultValue = "DESC") String direction,
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) DifficultyLevel difficulty) {
+        
+        Sort.Direction sortDirection = direction.equalsIgnoreCase("ASC") 
+                ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+
+        Page<VideoResponse> videos;
+        if (categoryId != null) {
+            videos = videoService.getVideosByCategory(categoryId, pageable);
+        } else if (difficulty != null) {
+            videos = videoService.getVideosByDifficulty(difficulty, pageable);
+        } else {
+            videos = videoService.getAllVideos(pageable);
+        }
+
+        return ResponseEntity.ok(videos);
+    }
+
+    // 특정 비디오 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<VideoResponse> getVideoById(@PathVariable Long id) {
+        VideoResponse video = videoService.getVideoById(id);
+        return ResponseEntity.ok(video);
+    }
+
+    // 비디오 생성 (강사/관리자)
+    @PostMapping
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    public ResponseEntity<VideoResponse> createVideo(@Valid @RequestBody VideoRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        VideoResponse video = videoService.createVideo(request, email);
+        return ResponseEntity.status(HttpStatus.CREATED).body(video);
+    }
+
+    // 비디오 수정 (본인 또는 관리자)
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    public ResponseEntity<VideoResponse> updateVideo(
+            @PathVariable Long id,
+            @Valid @RequestBody VideoRequest request) {
+        
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        VideoResponse video = videoService.updateVideo(id, request, email);
+        return ResponseEntity.ok(video);
+    }
+
+    // 비디오 삭제 (본인 또는 관리자)
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    public ResponseEntity<Void> deleteVideo(@PathVariable Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        videoService.deleteVideo(id, email);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 조회수 증가
+    @PostMapping("/{id}/view")
+    public ResponseEntity<Map<String, Long>> incrementViews(@PathVariable Long id) {
+        Map<String, Long> response = videoService.incrementViews(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/dto/VideoRequest.java
+++ b/backend/src/main/java/com/learnsnap/dto/VideoRequest.java
@@ -1,0 +1,42 @@
+package com.learnsnap.dto;
+
+import com.learnsnap.domain.video.DifficultyLevel;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoRequest {
+
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
+    private String title;
+
+    @Size(max = 1000, message = "설명은 1000자 이하여야 합니다")
+    private String description;
+
+    @NotBlank(message = "비디오 URL은 필수입니다")
+    @Size(max = 500, message = "비디오 URL은 500자 이하여야 합니다")
+    private String videoUrl;
+
+    @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다")
+    private String thumbnailUrl;
+
+    @NotNull(message = "재생 시간은 필수입니다")
+    @Min(value = 1, message = "재생 시간은 1초 이상이어야 합니다")
+    private Integer duration;
+
+    @NotNull(message = "난이도는 필수입니다")
+    private DifficultyLevel difficultyLevel;
+
+    @NotNull(message = "카테고리 ID는 필수입니다")
+    private Long categoryId;
+}

--- a/backend/src/main/java/com/learnsnap/dto/VideoResponse.java
+++ b/backend/src/main/java/com/learnsnap/dto/VideoResponse.java
@@ -1,0 +1,42 @@
+package com.learnsnap.dto;
+
+import com.learnsnap.domain.video.DifficultyLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private String videoUrl;
+    private String thumbnailUrl;
+    private Integer duration;
+    private DifficultyLevel difficultyLevel;
+    private CategoryResponse category;
+    private InstructorInfo instructor;
+    private Long viewsCount;
+    private Long likesCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // 강사 정보 (간단한 정보만)
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class InstructorInfo {
+        private Long id;
+        private String username;
+        private String email;
+        private String profileImage;
+    }
+}

--- a/backend/src/main/java/com/learnsnap/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/learnsnap/exception/GlobalExceptionHandler.java
@@ -86,4 +86,30 @@ public class GlobalExceptionHandler {
         
         return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
     }
+
+    // 비디오를 찾을 수 없음
+    @ExceptionHandler(VideoNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleVideoNotFound(VideoNotFoundException ex) {
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("Not Found")
+                .message(ex.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    // 권한 없음
+    @ExceptionHandler(UnauthorizedAccessException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedAccess(UnauthorizedAccessException ex) {
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.FORBIDDEN.value())
+                .error("Forbidden")
+                .message(ex.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+    }
 }

--- a/backend/src/main/java/com/learnsnap/exception/UnauthorizedAccessException.java
+++ b/backend/src/main/java/com/learnsnap/exception/UnauthorizedAccessException.java
@@ -1,0 +1,7 @@
+package com.learnsnap.exception;
+
+public class UnauthorizedAccessException extends RuntimeException {
+    public UnauthorizedAccessException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/exception/VideoNotFoundException.java
+++ b/backend/src/main/java/com/learnsnap/exception/VideoNotFoundException.java
@@ -1,0 +1,7 @@
+package com.learnsnap.exception;
+
+public class VideoNotFoundException extends RuntimeException {
+    public VideoNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/learnsnap/service/VideoService.java
+++ b/backend/src/main/java/com/learnsnap/service/VideoService.java
@@ -1,0 +1,194 @@
+package com.learnsnap.service;
+
+import com.learnsnap.domain.category.Category;
+import com.learnsnap.domain.user.Role;
+import com.learnsnap.domain.user.User;
+import com.learnsnap.domain.video.DifficultyLevel;
+import com.learnsnap.domain.video.Video;
+import com.learnsnap.dto.CategoryResponse;
+import com.learnsnap.dto.VideoRequest;
+import com.learnsnap.dto.VideoResponse;
+import com.learnsnap.exception.CategoryNotFoundException;
+import com.learnsnap.exception.UnauthorizedAccessException;
+import com.learnsnap.exception.VideoNotFoundException;
+import com.learnsnap.repository.CategoryRepository;
+import com.learnsnap.repository.UserRepository;
+import com.learnsnap.repository.VideoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class VideoService {
+
+    private final VideoRepository videoRepository;
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+
+    // 전체 비디오 조회 (페이징)
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> getAllVideos(Pageable pageable) {
+        return videoRepository.findAll(pageable)
+                .map(this::convertToResponse);
+    }
+
+    // 카테고리별 비디오 조회
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> getVideosByCategory(Long categoryId, Pageable pageable) {
+        return videoRepository.findByCategoryId(categoryId, pageable)
+                .map(this::convertToResponse);
+    }
+
+    // 난이도별 비디오 조회
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> getVideosByDifficulty(DifficultyLevel difficulty, Pageable pageable) {
+        return videoRepository.findByDifficultyLevel(difficulty, pageable)
+                .map(this::convertToResponse);
+    }
+
+    // 특정 비디오 조회
+    @Transactional(readOnly = true)
+    public VideoResponse getVideoById(Long id) {
+        Video video = videoRepository.findById(id)
+                .orElseThrow(() -> new VideoNotFoundException("비디오를 찾을 수 없습니다: " + id));
+        
+        return convertToResponse(video);
+    }
+
+    // 비디오 생성 (강사/관리자)
+    @Transactional
+    public VideoResponse createVideo(VideoRequest request, String email) {
+        // 강사 찾기
+        User instructor = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        // 카테고리 찾기
+        Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new CategoryNotFoundException("카테고리를 찾을 수 없습니다: " + request.getCategoryId()));
+
+        // 비디오 생성
+        Video video = Video.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .videoUrl(request.getVideoUrl())
+                .thumbnailUrl(request.getThumbnailUrl())
+                .duration(request.getDuration())
+                .difficultyLevel(request.getDifficultyLevel())
+                .category(category)
+                .instructor(instructor)
+                .build();
+
+        Video savedVideo = videoRepository.save(video);
+        return convertToResponse(savedVideo);
+    }
+
+    // 비디오 수정 (본인 또는 관리자)
+    @Transactional
+    public VideoResponse updateVideo(Long id, VideoRequest request, String email) {
+        // 비디오 찾기
+        Video video = videoRepository.findById(id)
+                .orElseThrow(() -> new VideoNotFoundException("비디오를 찾을 수 없습니다: " + id));
+
+        // 권한 확인
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        if (!video.getInstructor().getId().equals(user.getId()) && user.getRole() != Role.ADMIN) {
+            throw new UnauthorizedAccessException("이 비디오를 수정할 권한이 없습니다");
+        }
+
+        // 카테고리 찾기
+        Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new CategoryNotFoundException("카테고리를 찾을 수 없습니다: " + request.getCategoryId()));
+
+        // 업데이트
+        video.update(
+            request.getTitle(),
+            request.getDescription(),
+            request.getThumbnailUrl(),
+            request.getDuration(),
+            request.getDifficultyLevel(),
+            category
+        );
+
+        return convertToResponse(video);
+    }
+
+    // 비디오 삭제 (본인 또는 관리자)
+    @Transactional
+    public void deleteVideo(Long id, String email) {
+        // 비디오 찾기
+        Video video = videoRepository.findById(id)
+                .orElseThrow(() -> new VideoNotFoundException("비디오를 찾을 수 없습니다: " + id));
+
+        // 권한 확인
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        if (!video.getInstructor().getId().equals(user.getId()) && user.getRole() != Role.ADMIN) {
+            throw new UnauthorizedAccessException("이 비디오를 삭제할 권한이 없습니다");
+        }
+
+        videoRepository.delete(video);
+    }
+
+    // 조회수 증가
+    @Transactional
+    public Map<String, Long> incrementViews(Long id) {
+        Video video = videoRepository.findById(id)
+                .orElseThrow(() -> new VideoNotFoundException("비디오를 찾을 수 없습니다: " + id));
+
+        video.incrementViews();
+
+        Map<String, Long> response = new HashMap<>();
+        response.put("viewsCount", video.getViewsCount());
+        return response;
+    }
+
+    // Entity -> Response DTO 변환
+    private VideoResponse convertToResponse(Video video) {
+        return VideoResponse.builder()
+                .id(video.getId())
+                .title(video.getTitle())
+                .description(video.getDescription())
+                .videoUrl(video.getVideoUrl())
+                .thumbnailUrl(video.getThumbnailUrl())
+                .duration(video.getDuration())
+                .difficultyLevel(video.getDifficultyLevel())
+                .category(convertCategoryToResponse(video.getCategory()))
+                .instructor(convertInstructorToInfo(video.getInstructor()))
+                .viewsCount(video.getViewsCount())
+                .likesCount(video.getLikesCount())
+                .createdAt(video.getCreatedAt())
+                .updatedAt(video.getUpdatedAt())
+                .build();
+    }
+
+    private CategoryResponse convertCategoryToResponse(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .slug(category.getSlug())
+                .description(category.getDescription())
+                .icon(category.getIcon())
+                .createdAt(category.getCreatedAt())
+                .updatedAt(category.getUpdatedAt())
+                .build();
+    }
+
+    private VideoResponse.InstructorInfo convertInstructorToInfo(User instructor) {
+        return VideoResponse.InstructorInfo.builder()
+                .id(instructor.getId())
+                .username(instructor.getUsername())
+                .email(instructor.getEmail())
+                .profileImage(instructor.getProfileImage())
+                .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항
- VideoRequest, VideoResponse DTO 생성
- VideoNotFoundException, UnauthorizedAccessException 추가
- GlobalExceptionHandler에 비디오 예외 처리 추가
- VideoService 생성 (CRUD 로직)
- VideoController 생성
- 페이징, 정렬, 필터링 지원
- 권한 체크 (본인 또는 관리자만 수정/삭제)

## API 엔드포인트

### 조회 (인증 불필요)
- GET /api/videos - 전체 조회 (페이징)
- GET /api/videos?categoryId={id} - 카테고리별 조회
- GET /api/videos?difficulty={level} - 난이도별 조회
- GET /api/videos/{id} - 특정 비디오 조회

### 생성/수정/삭제 (인증 필요)
- POST /api/videos - 비디오 생성 (강사/관리자)
- PUT /api/videos/{id} - 비디오 수정 (본인/관리자)
- DELETE /api/videos/{id} - 비디오 삭제 (본인/관리자)

### 조회수
- POST /api/videos/{id}/view - 조회수 증가

## 주요 기능
- 페이징 (page, size)
- 정렬 (sort, direction)
- 필터링 (categoryId, difficulty)
- 권한 체크 (본인 또는 관리자만 수정/삭제 가능)
- 조회수 증가

## 테스트 완료
- [x] 전체 비디오 조회 (페이징)
- [x] 특정 비디오 조회
- [x] 카테고리별 조회
- [x] 난이도별 조회
- [x] 정렬 옵션 테스트
- [x] 비디오 생성 (강사)
- [x] 토큰 없이 생성 시도 → 403
- [x] 비디오 수정 (본인)
- [x] 다른 사람 비디오 수정 시도 → 403
- [x] 비디오 삭제 (본인)
- [x] 조회수 증가
- [x] 존재하지 않는 비디오 조회 → 404

Closes #28