### PR TITLE
(#29) ⭐ feat: 비디오 검색 및 필터링 API 구현

### DIFF
--- a/backend/src/main/java/com/learnsnap/controller/VideoController.java
+++ b/backend/src/main/java/com/learnsnap/controller/VideoController.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/videos")
@@ -100,5 +101,67 @@ public class VideoController {
     public ResponseEntity<Map<String, Long>> incrementViews(@PathVariable Long id) {
         Map<String, Long> response = videoService.incrementViews(id);
         return ResponseEntity.ok(response);
+    }
+
+    // 비디오 검색
+    @GetMapping("/search")
+    public ResponseEntity<Page<VideoResponse>> searchVideos(
+            @RequestParam String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<VideoResponse> videos = videoService.searchVideos(q, pageable);
+        return ResponseEntity.ok(videos);
+    }
+
+    // 카테고리별 비디오 조회 (난이도 필터 포함)
+    @GetMapping("/category/{categoryId}")
+    public ResponseEntity<Page<VideoResponse>> getVideosByCategory(
+            @PathVariable Long categoryId,
+            @RequestParam(required = false) DifficultyLevel difficulty,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        
+        Page<VideoResponse> videos;
+        if (difficulty != null) {
+            videos = videoService.getVideosByCategoryAndDifficulty(categoryId, difficulty, pageable);
+        } else {
+            videos = videoService.getVideosByCategory(categoryId, pageable);
+        }
+        
+        return ResponseEntity.ok(videos);
+    }
+
+    // 강사별 비디오 조회
+    @GetMapping("/instructor/{instructorId}")
+    public ResponseEntity<Page<VideoResponse>> getVideosByInstructor(
+            @PathVariable Long instructorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<VideoResponse> videos = videoService.getVideosByInstructor(instructorId, pageable);
+        return ResponseEntity.ok(videos);
+    }
+
+    // 인기 비디오
+    @GetMapping("/popular")
+    public ResponseEntity<List<VideoResponse>> getPopularVideos(
+            @RequestParam(defaultValue = "10") int limit) {
+        
+        List<VideoResponse> videos = videoService.getPopularVideos(limit);
+        return ResponseEntity.ok(videos);
+    }
+
+    // 최신 비디오
+    @GetMapping("/recent")
+    public ResponseEntity<List<VideoResponse>> getRecentVideos(
+            @RequestParam(defaultValue = "10") int limit) {
+        
+        List<VideoResponse> videos = videoService.getRecentVideos(limit);
+        return ResponseEntity.ok(videos);
     }
 }

--- a/backend/src/main/java/com/learnsnap/service/VideoService.java
+++ b/backend/src/main/java/com/learnsnap/service/VideoService.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -190,5 +192,49 @@ public class VideoService {
                 .email(instructor.getEmail())
                 .profileImage(instructor.getProfileImage())
                 .build();
+    }
+
+    // 제목 또는 설명으로 검색
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> searchVideos(String keyword, Pageable pageable) {
+        return videoRepository.findByTitleContainingOrDescriptionContaining(
+                keyword, keyword, pageable)
+                .map(this::convertToResponse);
+    }
+
+    // 강사별 비디오 조회
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> getVideosByInstructor(Long instructorId, Pageable pageable) {
+        return videoRepository.findByInstructorId(instructorId, pageable)
+                .map(this::convertToResponse);
+    }
+
+    // 카테고리와 난이도로 필터링
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> getVideosByCategoryAndDifficulty(
+            Long categoryId, DifficultyLevel difficulty, Pageable pageable) {
+        return videoRepository.findByCategoryIdAndDifficultyLevel(
+                categoryId, difficulty, pageable)
+                .map(this::convertToResponse);
+    }
+
+    // 인기 비디오 (조회수 많은 순)
+    @Transactional(readOnly = true)
+    public List<VideoResponse> getPopularVideos(int limit) {
+        List<Video> videos = videoRepository.findTop10ByOrderByViewsCountDesc();
+        return videos.stream()
+                .limit(limit)
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+    }
+
+    // 최신 비디오
+    @Transactional(readOnly = true)
+    public List<VideoResponse> getRecentVideos(int limit) {
+        List<Video> videos = videoRepository.findTop10ByOrderByCreatedAtDesc();
+        return videos.stream()
+                .limit(limit)
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 변경 사항
- VideoService에 검색 및 필터링 메서드 추가
- VideoController에 검색 및 필터링 엔드포인트 추가

## API 엔드포인트

### 검색
- GET /api/videos/search?q={keyword} - 제목/설명 검색

### 필터링
- GET /api/videos/category/{categoryId} - 카테고리별
- GET /api/videos/category/{categoryId}?difficulty={level} - 카테고리+난이도
- GET /api/videos/instructor/{instructorId} - 강사별

### 정렬
- GET /api/videos/popular?limit={n} - 인기 비디오 (조회수 순)
- GET /api/videos/recent?limit={n} - 최신 비디오

## 주요 기능
- 제목 또는 설명으로 검색
- 카테고리별 필터링
- 난이도별 필터링
- 카테고리 + 난이도 조합 필터링
- 강사별 조회
- 인기 비디오 (조회수 많은 순)
- 최신 비디오 (생성일 최신 순)
- 모든 엔드포인트 페이징 지원

## 테스트 완료
- [x] 제목으로 검색
- [x] 설명으로 검색
- [x] 카테고리별 조회
- [x] 카테고리 + 난이도 필터
- [x] 강사별 조회
- [x] 인기 비디오 조회
- [x] 최신 비디오 조회
- [x] 검색 결과 없음 처리
- [x] 페이징 동작 확인

Closes #29