### PR TITLE
(#42) ⭐ feat: 비디오 목록 페이지 API 연동 및 페이징 구현

### DIFF
--- a/frontend/src/components/common/Pagination.jsx
+++ b/frontend/src/components/common/Pagination.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+const Pagination = ({ currentPage, totalPages, onPageChange }) => {
+  // 페이지 번호 배열 생성
+  const getPageNumbers = () => {
+    const pages = [];
+    const maxPagesToShow = 5;
+    
+    let startPage = Math.max(0, currentPage - Math.floor(maxPagesToShow / 2));
+    let endPage = Math.min(totalPages - 1, startPage + maxPagesToShow - 1);
+    
+    // 끝에서 시작할 경우 조정
+    if (endPage - startPage < maxPagesToShow - 1) {
+      startPage = Math.max(0, endPage - maxPagesToShow + 1);
+    }
+    
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(i);
+    }
+    
+    return pages;
+  };
+
+  const pageNumbers = getPageNumbers();
+
+  return (
+    <div className="flex items-center justify-center space-x-2 mt-8">
+      {/* 이전 버튼 */}
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 0}
+        className={`px-3 py-2 rounded ${
+          currentPage === 0
+            ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+            : 'bg-white border hover:bg-gray-50'
+        }`}
+      >
+        이전
+      </button>
+
+      {/* 첫 페이지 */}
+      {pageNumbers[0] > 0 && (
+        <>
+          <button
+            onClick={() => onPageChange(0)}
+            className="px-3 py-2 rounded bg-white border hover:bg-gray-50"
+          >
+            1
+          </button>
+          {pageNumbers[0] > 1 && <span className="px-2">...</span>}
+        </>
+      )}
+
+      {/* 페이지 번호들 */}
+      {pageNumbers.map((page) => (
+        <button
+          key={page}
+          onClick={() => onPageChange(page)}
+          className={`px-3 py-2 rounded ${
+            page === currentPage
+              ? 'bg-blue-500 text-white'
+              : 'bg-white border hover:bg-gray-50'
+          }`}
+        >
+          {page + 1}
+        </button>
+      ))}
+
+      {/* 마지막 페이지 */}
+      {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
+        <>
+          {pageNumbers[pageNumbers.length - 1] < totalPages - 2 && (
+            <span className="px-2">...</span>
+          )}
+          <button
+            onClick={() => onPageChange(totalPages - 1)}
+            className="px-3 py-2 rounded bg-white border hover:bg-gray-50"
+          >
+            {totalPages}
+          </button>
+        </>
+      )}
+
+      {/* 다음 버튼 */}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage >= totalPages - 1}
+        className={`px-3 py-2 rounded ${
+          currentPage >= totalPages - 1
+            ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+            : 'bg-white border hover:bg-gray-50'
+        }`}
+      >
+        다음
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/components/video/VideoCard.jsx
+++ b/frontend/src/components/video/VideoCard.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const VideoCard = ({ video }) => {
+  // 난이도 한글 변환
+  const getDifficultyText = (level) => {
+    const difficultyMap = {
+      'BEGINNER': '초급',
+      'INTERMEDIATE': '중급',
+      'ADVANCED': '고급'
+    };
+    return difficultyMap[level] || level;
+  };
+
+  // 난이도별 색상
+  const getDifficultyColor = (level) => {
+    const colorMap = {
+      'BEGINNER': 'bg-green-100 text-green-800',
+      'INTERMEDIATE': 'bg-yellow-100 text-yellow-800',
+      'ADVANCED': 'bg-red-100 text-red-800'
+    };
+    return colorMap[level] || 'bg-gray-100 text-gray-800';
+  };
+
+  return (
+    <Link 
+      to={`/videos/${video.id}`}
+      className="block border rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+    >
+      {/* 썸네일 */}
+      <div className="relative">
+        {video.thumbnailUrl ? (
+          <img 
+            src={video.thumbnailUrl} 
+            alt={video.title}
+            className="w-full h-48 object-cover"
+          />
+        ) : (
+          <div className="w-full h-48 bg-gradient-to-br from-blue-400 to-purple-500 flex items-center justify-center">
+            <span className="text-white text-4xl">🎥</span>
+          </div>
+        )}
+        
+        {/* 난이도 뱃지 */}
+        <div className="absolute top-2 right-2">
+          <span className={`px-2 py-1 rounded text-xs font-semibold ${getDifficultyColor(video.difficultyLevel)}`}>
+            {getDifficultyText(video.difficultyLevel)}
+          </span>
+        </div>
+
+        {/* 재생 시간 */}
+        {video.duration && (
+          <div className="absolute bottom-2 right-2">
+            <span className="px-2 py-1 bg-black bg-opacity-75 text-white text-xs rounded">
+              {Math.floor(video.duration / 60)}:{String(video.duration % 60).padStart(2, '0')}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* 비디오 정보 */}
+      <div className="p-4">
+        {/* 제목 */}
+        <h3 className="font-semibold mb-2 line-clamp-2 hover:text-blue-600">
+          {video.title}
+        </h3>
+
+        {/* 강사명 */}
+        <p className="text-sm text-gray-600 mb-1">
+          {video.instructor?.username || '익명'}
+        </p>
+
+        {/* 카테고리 */}
+        {video.category && (
+          <p className="text-xs text-blue-600 mb-2">
+            {video.category.name}
+          </p>
+        )}
+
+        {/* 조회수 및 좋아요 */}
+        <div className="flex items-center justify-between text-sm text-gray-500">
+          <span>조회수 {video.viewsCount?.toLocaleString() || 0}회</span>
+          <span>❤️ {video.likesCount?.toLocaleString() || 0}</span>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default VideoCard;

--- a/frontend/src/pages/Videos/VideosPage.jsx
+++ b/frontend/src/pages/Videos/VideosPage.jsx
@@ -1,22 +1,129 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { getVideos } from '../../services/videoService';
+import VideoCard from '../../components/video/VideoCard';
+import Pagination from '../../components/common/Pagination';
 
 const VideosPage = () => {
+  // 상태 관리
+  const [videos, setVideos] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  
+  // 페이징 상태
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+  const pageSize = 9; // 한 페이지에 9개씩 (3x3 그리드)
+
+  // 비디오 목록 불러오기
+  const fetchVideos = async (page = 0) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await getVideos({
+        page: page,
+        size: pageSize,
+        sort: 'createdAt,desc' // 최신순
+      });
+
+      setVideos(response.content);
+      setCurrentPage(response.page);
+      setTotalPages(response.totalPages);
+      setTotalElements(response.totalElements);
+    } catch (err) {
+      console.error('비디오 목록 불러오기 실패:', err);
+      setError('비디오 목록을 불러오는 데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 컴포넌트 마운트 시 비디오 불러오기
+  useEffect(() => {
+    fetchVideos(currentPage);
+  }, [currentPage]);
+
+  // 페이지 변경 핸들러
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  // 로딩 중
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">모든 비디오</h1>
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
+            <p className="mt-4 text-gray-600">비디오를 불러오는 중...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러 발생
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">모든 비디오</h1>
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <p className="text-red-600 text-lg mb-4">{error}</p>
+            <button
+              onClick={() => fetchVideos(currentPage)}
+              className="bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600"
+            >
+              다시 시도
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 비디오 없음
+  if (videos.length === 0) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">모든 비디오</h1>
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <p className="text-gray-600 text-lg">아직 등록된 비디오가 없습니다.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6">모든 비디오</h1>
-      
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {[1, 2, 3, 4, 5, 6].map((item) => (
-          <div key={item} className="border rounded-lg overflow-hidden shadow-sm">
-            <div className="bg-gray-200 h-48"></div>
-            <div className="p-4">
-              <h3 className="font-semibold mb-2">비디오 제목 {item}</h3>
-              <p className="text-sm text-gray-600">강사명</p>
-              <p className="text-sm text-gray-500 mt-2">조회수 150회</p>
-            </div>
-          </div>
+      {/* 헤더 */}
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold">모든 비디오</h1>
+        <p className="text-gray-600">
+          총 {totalElements.toLocaleString()}개의 비디오
+        </p>
+      </div>
+
+      {/* 비디오 그리드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {videos.map((video) => (
+          <VideoCard key={video.id} video={video} />
         ))}
       </div>
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 변경 사항
- VideoCard 컴포넌트 생성
- Pagination 컴포넌트 생성
- VideosPage API 연동
- 페이징 기능 구현
- 로딩/에러 상태 처리

## 주요 기능

### VideoCard.jsx
- 비디오 썸네일 표시
- 난이도 뱃지 (초급/중급/고급)
- 제목, 강사명, 카테고리
- 조회수, 좋아요 수
- 재생 시간 표시
- 클릭 시 상세 페이지 이동

### Pagination.jsx
- 페이지 번호 표시
- 이전/다음 버튼
- 현재 페이지 하이라이트
- 첫/마지막 페이지 바로가기

### VideosPage.jsx
- videoService.getVideos() API 호출
- 페이징 파라미터 (page, size, sort)
- 로딩 스피너
- 에러 처리 및 재시도
- 비디오 없을 때 처리
- 총 개수 표시
- 페이지 변경 시 스크롤 상단 이동

## 테스트 완료
- [x] API 연동 정상 동작
- [x] 페이징 동작 확인
- [x] 로딩 스피너 표시
- [x] 에러 처리 동작
- [x] 비디오 카드 클릭 시 상세 페이지 이동
- [x] 반응형 레이아웃 (모바일/태블릿/데스크톱)

Closes #42