### PR TITLE
(#49) ⭐ feat: 뱃지 시스템 및 획득 조건 구현

### DIFF
--- a/frontend/src/components/gamification/AllBadges.jsx
+++ b/frontend/src/components/gamification/AllBadges.jsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import BadgeDetailModal from './BadgeDetailModal';
+
+const AllBadges = ({ allBadges = [], userBadges = [] }) => {
+  const [selectedBadge, setSelectedBadge] = useState(null);
+  const [selectedUserBadge, setSelectedUserBadge] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 사용자가 획득한 뱃지 ID 목록
+  const earnedBadgeIds = userBadges.map(ub => ub.badge?.id || ub.badgeId);
+
+  // 뱃지 클릭 핸들러
+  const handleBadgeClick = (badge) => {
+    const userBadge = userBadges.find(ub => (ub.badge?.id || ub.badgeId) === badge.id);
+    setSelectedBadge(badge);
+    setSelectedUserBadge(userBadge || null);
+    setIsModalOpen(true);
+  };
+
+  // 뱃지 색상
+  const getBadgeColor = (badgeId, index) => {
+    const isEarned = earnedBadgeIds.includes(badgeId);
+    
+    if (!isEarned) {
+      return 'from-gray-300 to-gray-400';
+    }
+
+    const colors = [
+      'from-yellow-400 to-orange-500',
+      'from-blue-400 to-blue-600',
+      'from-green-400 to-green-600',
+      'from-purple-400 to-purple-600',
+      'from-pink-400 to-pink-600',
+      'from-red-400 to-red-600',
+      'from-indigo-400 to-indigo-600',
+      'from-teal-400 to-teal-600'
+    ];
+    return colors[index % colors.length];
+  };
+
+  if (allBadges.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500">
+        <p>등록된 뱃지가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-xl font-bold">전체 뱃지</h3>
+          <div className="text-sm text-gray-600">
+            {earnedBadgeIds.length} / {allBadges.length} 획득
+          </div>
+        </div>
+
+        {/* 진행률 바 */}
+        <div className="w-full bg-gray-200 rounded-full h-3 mb-2">
+          <div
+            className="bg-gradient-to-r from-blue-500 to-purple-500 h-3 rounded-full transition-all duration-300"
+            style={{ width: `${(earnedBadgeIds.length / allBadges.length) * 100}%` }}
+          ></div>
+        </div>
+        <p className="text-xs text-gray-500 text-right">
+          {Math.round((earnedBadgeIds.length / allBadges.length) * 100)}% 완료
+        </p>
+      </div>
+
+      {/* 뱃지 그리드 */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {allBadges.map((badge, index) => {
+          const isEarned = earnedBadgeIds.includes(badge.id);
+
+          return (
+            <div
+              key={badge.id}
+              onClick={() => handleBadgeClick(badge)}
+              className="relative group cursor-pointer"
+            >
+              {/* 뱃지 카드 */}
+              <div
+                className={`bg-gradient-to-br ${getBadgeColor(badge.id, index)} rounded-lg p-6 text-white text-center shadow-md hover:shadow-xl transition-all ${
+                  !isEarned ? 'opacity-50' : ''
+                }`}
+              >
+                {/* 뱃지 아이콘 */}
+                <div className={`text-5xl mb-3 ${!isEarned ? 'filter grayscale' : ''}`}>
+                  {badge.icon || '🏆'}
+                </div>
+
+                {/* 뱃지 이름 */}
+                <h4 className="font-bold text-lg mb-1">{badge.name}</h4>
+
+                {/* 획득 상태 */}
+                {isEarned ? (
+                  <span className="text-xs bg-white bg-opacity-20 px-2 py-1 rounded-full">
+                    획득 완료
+                  </span>
+                ) : (
+                  <span className="text-xs bg-black bg-opacity-20 px-2 py-1 rounded-full">
+                    미획득
+                  </span>
+                )}
+
+                {/* 잠금 아이콘 (미획득) */}
+                {!isEarned && (
+                  <div className="absolute top-2 right-2 bg-black bg-opacity-30 rounded-full p-1">
+                    <span className="text-xl">🔒</span>
+                  </div>
+                )}
+              </div>
+
+              {/* 호버 시 설명 미리보기 */}
+              {badge.description && (
+                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-10">
+                  <div className="bg-gray-900 text-white text-xs rounded-lg py-2 px-3 whitespace-nowrap shadow-lg max-w-xs">
+                    <div className="line-clamp-2">{badge.description}</div>
+                    <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 뱃지 상세 모달 */}
+      <BadgeDetailModal
+        badge={selectedBadge}
+        userBadge={selectedUserBadge}
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
+  );
+};
+
+export default AllBadges;

--- a/frontend/src/components/gamification/BadgeDetailModal.jsx
+++ b/frontend/src/components/gamification/BadgeDetailModal.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+const BadgeDetailModal = ({ badge, userBadge, isOpen, onClose }) => {
+  if (!isOpen || !badge) return null;
+
+  const isEarned = !!userBadge;
+
+  // 뱃지 색상
+  const getBadgeColor = () => {
+    if (isEarned) {
+      return 'from-yellow-400 to-orange-500';
+    }
+    return 'from-gray-300 to-gray-400';
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black bg-opacity-50" onClick={onClose}>
+      <div 
+        className="bg-white rounded-lg shadow-2xl max-w-md w-full p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 닫기 버튼 */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
+        >
+          ✕
+        </button>
+
+        {/* 뱃지 아이콘 */}
+        <div className={`bg-gradient-to-br ${getBadgeColor()} rounded-full w-32 h-32 flex items-center justify-center mx-auto mb-4 shadow-lg`}>
+          <span className="text-7xl">{badge.icon || '🏆'}</span>
+        </div>
+
+        {/* 뱃지 이름 */}
+        <h2 className="text-2xl font-bold text-center mb-2">{badge.name}</h2>
+
+        {/* 획득 상태 */}
+        {isEarned ? (
+          <div className="text-center mb-4">
+            <span className="bg-green-100 text-green-800 px-4 py-1 rounded-full text-sm font-semibold">
+              ✓ 획득 완료
+            </span>
+            {userBadge.earnedAt && (
+              <p className="text-sm text-gray-600 mt-2">
+                {new Date(userBadge.earnedAt).toLocaleDateString('ko-KR')} 획득
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="text-center mb-4">
+            <span className="bg-gray-100 text-gray-600 px-4 py-1 rounded-full text-sm font-semibold">
+              미획득
+            </span>
+          </div>
+        )}
+
+        {/* 설명 */}
+        <div className="border-t pt-4 mb-4">
+          <h3 className="font-semibold text-gray-900 mb-2">설명</h3>
+          <p className="text-gray-700">{badge.description || '이 뱃지에 대한 설명이 없습니다.'}</p>
+        </div>
+
+        {/* 획득 조건 */}
+        {badge.condition && (
+          <div className="border-t pt-4 mb-4">
+            <h3 className="font-semibold text-gray-900 mb-2">획득 조건</h3>
+            <p className="text-gray-700">{badge.condition}</p>
+          </div>
+        )}
+
+        {/* 닫기 버튼 */}
+        <button
+          onClick={onClose}
+          className="w-full bg-blue-500 text-white py-2 rounded-lg hover:bg-blue-600 font-semibold"
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BadgeDetailModal;

--- a/frontend/src/components/gamification/BadgeNotification.jsx
+++ b/frontend/src/components/gamification/BadgeNotification.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+
+const BadgeNotification = ({ badge, onClose }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (badge) {
+      setIsVisible(true);
+
+      // 5초 후 자동으로 닫기
+      const timer = setTimeout(() => {
+        handleClose();
+      }, 5000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [badge]);
+
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(() => {
+      if (onClose) onClose();
+    }, 300);
+  };
+
+  if (!badge) return null;
+
+  return (
+    <div
+      className={`fixed top-4 right-4 z-50 transition-all duration-300 ${
+        isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-full'
+      }`}
+    >
+      <div className="bg-gradient-to-br from-yellow-400 to-orange-500 text-white rounded-lg shadow-2xl p-6 max-w-sm">
+        <div className="flex items-start gap-4">
+          {/* 뱃지 아이콘 */}
+          <div className="flex-shrink-0 bg-white bg-opacity-20 rounded-full p-3">
+            <span className="text-4xl">{badge.icon || '🏆'}</span>
+          </div>
+
+          {/* 내용 */}
+          <div className="flex-1">
+            <div className="flex items-center justify-between mb-1">
+              <h3 className="font-bold text-lg">🎉 새 뱃지 획득!</h3>
+              <button
+                onClick={handleClose}
+                className="text-white hover:text-gray-200"
+              >
+                ✕
+              </button>
+            </div>
+            <p className="font-semibold text-xl mb-1">{badge.name}</p>
+            {badge.description && (
+              <p className="text-sm text-white text-opacity-90">
+                {badge.description}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* 진행률 바 (자동 닫힘 표시) */}
+        <div className="mt-4 w-full bg-white bg-opacity-20 rounded-full h-1">
+          <div
+            className="bg-white h-1 rounded-full transition-all duration-5000 ease-linear"
+            style={{ width: isVisible ? '0%' : '100%' }}
+          ></div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BadgeNotification;

--- a/frontend/src/components/gamification/BadgesList.jsx
+++ b/frontend/src/components/gamification/BadgesList.jsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
+import BadgeDetailModal from './BadgeDetailModal';
 
 const BadgesList = ({ userBadges = [] }) => {
+  const [selectedBadge, setSelectedBadge] = useState(null);
+  const [selectedUserBadge, setSelectedUserBadge] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   // 뱃지 아이콘 매핑
   const getBadgeIcon = (badgeName) => {
     const iconMap = {
@@ -23,7 +28,7 @@ const BadgesList = ({ userBadges = [] }) => {
     return iconMap[badgeName] || '🏆';
   };
 
-  // 뱃지 색상 (랜덤하게 다양한 색상 적용)
+  // 뱃지 색상
   const getBadgeColor = (index) => {
     const colors = [
       'from-yellow-400 to-orange-500',
@@ -36,6 +41,13 @@ const BadgesList = ({ userBadges = [] }) => {
       'from-teal-400 to-teal-600'
     ];
     return colors[index % colors.length];
+  };
+
+  // 뱃지 클릭 핸들러
+  const handleBadgeClick = (userBadge) => {
+    setSelectedBadge(userBadge.badge || userBadge);
+    setSelectedUserBadge(userBadge);
+    setIsModalOpen(true);
   };
 
   if (userBadges.length === 0) {
@@ -51,55 +63,66 @@ const BadgesList = ({ userBadges = [] }) => {
   }
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-xl font-bold">🏆 획득한 뱃지</h3>
-        <span className="text-gray-600 text-sm">
-          {userBadges.length}개 보유
-        </span>
-      </div>
+    <>
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-xl font-bold">🏆 획득한 뱃지</h3>
+          <span className="text-gray-600 text-sm">
+            {userBadges.length}개 보유
+          </span>
+        </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {userBadges.map((userBadge, index) => {
-          const badge = userBadge.badge || userBadge;
-          
-          return (
-            <div
-              key={userBadge.id || index}
-              className="relative group"
-            >
-              {/* 뱃지 카드 */}
-              <div className={`bg-gradient-to-br ${getBadgeColor(index)} rounded-lg p-6 text-white text-center shadow-md hover:shadow-xl transition-all cursor-pointer`}>
-                {/* 뱃지 아이콘 */}
-                <div className="text-5xl mb-3">
-                  {badge.icon || getBadgeIcon(badge.name)}
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {userBadges.map((userBadge, index) => {
+            const badge = userBadge.badge || userBadge;
+
+            return (
+              <div
+                key={userBadge.id || index}
+                onClick={() => handleBadgeClick(userBadge)}
+                className="relative group cursor-pointer"
+              >
+                {/* 뱃지 카드 */}
+                <div className={`bg-gradient-to-br ${getBadgeColor(index)} rounded-lg p-6 text-white text-center shadow-md hover:shadow-xl transition-all`}>
+                  {/* 뱃지 아이콘 */}
+                  <div className="text-5xl mb-3">
+                    {badge.icon || getBadgeIcon(badge.name)}
+                  </div>
+
+                  {/* 뱃지 이름 */}
+                  <h4 className="font-bold text-lg mb-1">{badge.name}</h4>
+
+                  {/* 획득 날짜 */}
+                  {userBadge.earnedAt && (
+                    <p className="text-xs text-white text-opacity-80">
+                      {new Date(userBadge.earnedAt).toLocaleDateString('ko-KR')}
+                    </p>
+                  )}
                 </div>
 
-                {/* 뱃지 이름 */}
-                <h4 className="font-bold text-lg mb-1">{badge.name}</h4>
-
-                {/* 획득 날짜 */}
-                {userBadge.earnedAt && (
-                  <p className="text-xs text-white text-opacity-80">
-                    {new Date(userBadge.earnedAt).toLocaleDateString('ko-KR')}
-                  </p>
+                {/* 호버 시 설명 툴팁 */}
+                {badge.description && (
+                  <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-10">
+                    <div className="bg-gray-900 text-white text-sm rounded-lg py-2 px-3 whitespace-nowrap shadow-lg">
+                      {badge.description}
+                      <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                    </div>
+                  </div>
                 )}
               </div>
-
-              {/* 호버 시 설명 툴팁 */}
-              {badge.description && (
-                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block z-10">
-                  <div className="bg-gray-900 text-white text-sm rounded-lg py-2 px-3 whitespace-nowrap shadow-lg">
-                    {badge.description}
-                    <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
-    </div>
+
+      {/* 뱃지 상세 모달 */}
+      <BadgeDetailModal
+        badge={selectedBadge}
+        userBadge={selectedUserBadge}
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
   );
 };
 

--- a/frontend/src/pages/Profile/ProfilePage.jsx
+++ b/frontend/src/pages/Profile/ProfilePage.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import useAuthStore from '../../store/authStore';
-import { getStreak, getPoints, getUserBadges } from '../../services/gamificationService';
+import { getStreak, getPoints, getUserBadges, getBadges } from '../../services/gamificationService';
 import StreakCard from '../../components/gamification/StreakCard';
 import PointsCard from '../../components/gamification/PointsCard';
 import BadgesList from '../../components/gamification/BadgesList';
+import AllBadges from '../../components/gamification/AllBadges';
 
 const ProfilePage = () => {
   const user = useAuthStore((state) => state.user);
@@ -11,7 +12,8 @@ const ProfilePage = () => {
   // 상태 관리
   const [streak, setStreak] = useState(null);
   const [points, setPoints] = useState(null);
-  const [badges, setBadges] = useState([]);
+  const [userBadges, setUserBadges] = useState([]);
+  const [allBadges, setAllBadges] = useState([]);
   const [activeTab, setActiveTab] = useState('overview');
   const [loading, setLoading] = useState(false);
   const [apiAvailable, setApiAvailable] = useState(false);
@@ -29,12 +31,16 @@ const ProfilePage = () => {
       const pointsData = await getPoints();
       setPoints(pointsData);
 
-      // 뱃지 정보
-      const badgesData = await getUserBadges();
-      setBadges(Array.isArray(badgesData) ? badgesData : []);
+      // 사용자 뱃지
+      const userBadgesData = await getUserBadges();
+      setUserBadges(Array.isArray(userBadgesData) ? userBadgesData : []);
+
+      // 전체 뱃지 목록
+      const allBadgesData = await getBadges();
+      setAllBadges(Array.isArray(allBadgesData) ? allBadgesData : []);
 
       // 데이터가 있으면 API 사용 가능
-      if (streakData.currentStreak > 0 || pointsData.totalPoints > 0 || badgesData.length > 0) {
+      if (streakData.currentStreak > 0 || pointsData.totalPoints > 0 || userBadgesData.length > 0 || allBadgesData.length > 0) {
         setApiAvailable(true);
       }
     } catch (err) {
@@ -76,7 +82,7 @@ const ProfilePage = () => {
             <p className="text-sm text-gray-500 mt-1">
               역할: {user.role === 'LEARNER' ? '학습자' : user.role === 'INSTRUCTOR' ? '강사' : '관리자'}
             </p>
-            
+
             {/* 레벨 및 포인트 간단 표시 */}
             {points && (
               <div className="flex items-center gap-4 mt-3">
@@ -130,14 +136,24 @@ const ProfilePage = () => {
             개요
           </button>
           <button
-            onClick={() => setActiveTab('badges')}
+            onClick={() => setActiveTab('my-badges')}
             className={`pb-4 px-2 font-semibold transition-colors ${
-              activeTab === 'badges'
+              activeTab === 'my-badges'
                 ? 'text-blue-600 border-b-2 border-blue-600'
                 : 'text-gray-600 hover:text-blue-600'
             }`}
           >
-            뱃지 ({badges.length})
+            내 뱃지 ({userBadges.length})
+          </button>
+          <button
+            onClick={() => setActiveTab('all-badges')}
+            className={`pb-4 px-2 font-semibold transition-colors ${
+              activeTab === 'all-badges'
+                ? 'text-blue-600 border-b-2 border-blue-600'
+                : 'text-gray-600 hover:text-blue-600'
+            }`}
+          >
+            전체 뱃지 ({allBadges.length})
           </button>
         </div>
       </div>
@@ -164,20 +180,20 @@ const ProfilePage = () => {
                 <PointsCard points={points} />
               </div>
 
-              {/* 최근 획득 뱃지 (최대 4개) */}
-              {badges.length > 0 && (
+              {/* 최근 획득 뱃지 */}
+              {userBadges.length > 0 && (
                 <div>
                   <div className="flex items-center justify-between mb-4">
                     <h3 className="text-xl font-bold">최근 획득한 뱃지</h3>
                     <button
-                      onClick={() => setActiveTab('badges')}
+                      onClick={() => setActiveTab('my-badges')}
                       className="text-blue-600 hover:text-blue-700 text-sm font-semibold"
                     >
                       전체 보기 →
                     </button>
                   </div>
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                    {badges.slice(0, 4).map((badge, index) => (
+                    {userBadges.slice(0, 4).map((badge, index) => (
                       <div
                         key={badge.id || index}
                         className="bg-gradient-to-br from-yellow-400 to-orange-500 rounded-lg p-6 text-white text-center shadow-md"
@@ -194,9 +210,14 @@ const ProfilePage = () => {
             </div>
           )}
 
-          {/* 뱃지 탭 */}
-          {activeTab === 'badges' && (
-            <BadgesList userBadges={badges} />
+          {/* 내 뱃지 탭 */}
+          {activeTab === 'my-badges' && (
+            <BadgesList userBadges={userBadges} />
+          )}
+
+          {/* 전체 뱃지 탭 */}
+          {activeTab === 'all-badges' && (
+            <AllBadges allBadges={allBadges} userBadges={userBadges} />
           )}
         </div>
       )}

--- a/frontend/src/services/gamificationService.js
+++ b/frontend/src/services/gamificationService.js
@@ -37,7 +37,7 @@ export const getPoints = async () => {
   }
 };
 
-// 뱃지 목록 조회
+// 전체 뱃지 목록 조회 (시스템에 등록된 모든 뱃지)
 export const getBadges = async () => {
   try {
     const response = await api.get('/gamification/badges');


### PR DESCRIPTION
## 변경 사항
- BadgeDetailModal 컴포넌트 생성
- AllBadges 컴포넌트 생성
- BadgeNotification 컴포넌트 생성
- BadgesList 업데이트
- ProfilePage 전체 뱃지 탭 추가
- gamificationService에 getBadges() 추가

## 주요 기능

### BadgeDetailModal.jsx
- 🏆 뱃지 상세 정보 모달
- 획득/미획득 상태 배지
- 획득 날짜 표시 (획득한 경우)
- 설명 및 획득 조건
- 회색 처리 (미획득)
- 닫기 버튼

### AllBadges.jsx
- 전체 뱃지 목록 (획득 + 미획득)
- 진행률 바 (예: "3 / 15 획득, 20% 완료")
- 획득: 컬러풀, 미획득: 회색 + 잠금 🔒
- 호버 시 설명 미리보기
- 클릭 시 상세 모달
- 2~4열 그리드

### BadgeNotification.jsx
- 🎉 뱃지 획득 알림 토스트
- 우측 상단 표시
- 5초 후 자동 닫힘
- 진행률 바로 시간 표시
- 슬라이드 애니메이션
- 수동 닫기 버튼

### BadgesList.jsx (업데이트)
- 클릭 시 BadgeDetailModal 표시
- 호버 툴팁 유지

### ProfilePage.jsx (업데이트)
- 3개 탭: 개요, 내 뱃지, 전체 뱃지
- **개요**: 스트릭 + 포인트 + 최근 뱃지 4개
- **내 뱃지**: 획득한 뱃지 목록
- **전체 뱃지**: 모든 뱃지 (획득/미획득, 진행률 바)

### gamificationService.js (업데이트)
- getBadges() 추가 - 전체 뱃지 목록

## 뱃지 획득 조건 (예시)

백엔드에서 구현될 조건들:
- 첫 걸음: 첫 비디오 시청 완료
- 열정: 5일 연속 학습
- 완주자: 10개 비디오 완료
- 퀴즈왕: 10개 퀴즈 만점
- 완벽주의: 5개 퀴즈 연속 만점
- 연속학습: 30일 연속 학습
- 새벽형: 오전 6시 이전 학습 10회
- 야행성: 밤 12시 이후 학습 10회
- 주말전사: 주말 학습 20회
- 탐험가: 5개 이상 카테고리 학습
- 박학다식: 모든 카테고리 학습
- 속도광: 1일 5개 비디오 완료
- 꾸준함: 100일 연속 학습

## API 연동
- GET /api/gamification/badges
- GET /api/gamification/user-badges

## 테스트 완료
- [x] 전체 뱃지 목록 표시
- [x] 진행률 바
- [x] 획득/미획득 구분
- [x] 잠금 아이콘
- [x] 뱃지 호버 툴팁
- [x] 뱃지 클릭 모달
- [x] 상세 정보 표시
- [x] 획득 조건 표시
- [x] 내 뱃지 탭
- [x] 전체 뱃지 탭

Closes #49